### PR TITLE
Add jsonrpc.NewClientWithHTTPClient and fix some typos

### DIFF
--- a/jsonrpc/client.go
+++ b/jsonrpc/client.go
@@ -21,18 +21,28 @@ type Client interface {
 }
 
 // NewClient creates a new JSON-RPC Client.
-// Creates http.Transport with 3 max idel connections and 30 seconds idle timeout.
+// Creates http.Transport with 3 max idle connections and 30 seconds idle timeout, and 30 seconds connection timeout
+// NewClientWithHTTPClient can be used to override the connection timeout
+// NewClientWithTransport can be used to override the underlying transport
 func NewClient(url string) Client {
-	return NewClientWithTransport(url, &http.Transport{
-		MaxIdleConns:    3,
-		IdleConnTimeout: 30 * time.Second,
+	return NewClientWithHTTPClient(url, &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:    3,
+			IdleConnTimeout: 30 * time.Second,
+		},
+		Timeout: 30 * time.Second,
 	})
 }
 
 // NewClientWithTransport creates a new JSON-RPC Client with given URL and
 // `*http.Transport`
 func NewClientWithTransport(url string, t *http.Transport) Client {
-	return &client{url: url, http: &http.Client{Transport: t}}
+	return NewClientWithHTTPClient(url, &http.Client{Transport: t})
+}
+
+// NewClientWithHTTPClient creates a new JSON-RPC Client with given URL and `*http.Client`
+func NewClientWithHTTPClient(url string, httpClient *http.Client) Client {
+	return &client{url: url, http: httpClient}
 }
 
 type client struct {

--- a/testnet/const.go
+++ b/testnet/const.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	URL                  = "https://testnet.libra.org/v1"
-	FaucetURL            = "https://testnet.libra.org/mint"
-	ChainID         byte = 2
-	DDAcountAddress      = "000000000000000000000000000000DD"
+	URL                   = "https://testnet.libra.org/v1"
+	FaucetURL             = "https://testnet.libra.org/mint"
+	ChainID          byte = 2
+	DDAccountAddress      = "000000000000000000000000000000DD"
 )
 
 // Client is testnet client

--- a/testnet/faucet.go
+++ b/testnet/faucet.go
@@ -67,7 +67,7 @@ func Mint(authKey string, amount uint64, currencyCode string) (int, error) {
 
 func waitAccountSequence(seq int) {
 	for i := 0; i < 100; i++ {
-		account, err := Client.GetAccount(DDAcountAddress)
+		account, err := Client.GetAccount(DDAccountAddress)
 		if _, ok := err.(*libraclient.StaleResponseError); ok {
 			continue
 		}


### PR DESCRIPTION
This adds a new constructor for the jsonrpc client that supports passing a `*http.Client` with a 30 second default timeout. This allows the caller to pass their custom http.Client different timeouts. There were also two typos in DDAccount  and in jsonrpc package that's been fixed