### PR TITLE
fix examples, use bigger max gas for the transaction

### DIFF
--- a/examples/exampleutils/submit_and_wait.go
+++ b/examples/exampleutils/submit_and_wait.go
@@ -49,7 +49,7 @@ Retry:
 		address,
 		sequenceNum,
 		script,
-		1000, 0, "LBR",
+		1_000_000, 0, "LBR",
 		expiration,
 		testnet.ChainID,
 	)


### PR DESCRIPTION
Examples start to fail because of out of gas error.